### PR TITLE
Add caching step

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,13 +3,21 @@ name: Setup Rust Environment
 inputs:
   os:
     default: ubuntu-latest
-  rusthash:
-    description: Unique hash from toolchain action
-    required: true
+  toolchain:
+    default: stable
+  components:
+
 
 runs:
   using: composite
   steps:
+    - uses: actions-rs/toolchain@v1
+      id: toolchain-install
+      with:
+        profile: minimal
+        override: true
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}  
     - uses: actions/cache@v3
       with:
         path: |
@@ -18,4 +26,4 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ inputs.os }}-${{ inputs.rusthash }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ inputs.os }}-${{ steps.toolchain-install.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,8 +5,7 @@ inputs:
     default: ubuntu-latest
   rusthash:
     required: true
-      
-  
+
 steps:
   - uses: actions/cache@v3
     with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,19 @@
+name: Setup Rust Environment
+
+inputs:
+  os:
+    default: ubuntu-latest
+  rusthash:
+    required: true
+      
+  
+steps:
+  - uses: actions/cache@v3
+    with:
+      path: |
+        ~/.cargo/bin/
+        ~/.cargo/registry/index/
+        ~/.cargo/registry/cache/
+        ~/.cargo/git/db/
+        target/
+      key: ${{ inputs.os }}-${{ inputs.rusthash }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,11 +2,16 @@ name: Setup Rust Environment
 
 inputs:
   os:
+    description: Runner Type for generating hash-key
     default: ubuntu-latest
+    required: false
   toolchain:
+    description: Pass-through to tailchain on actions-rs
     default: stable
+    required: false
   components:
-
+    description: Pass-through to components on actions-rs
+    required: false
 
 runs:
   using: composite
@@ -26,4 +31,4 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ inputs.os }}-${{ steps.toolchain-install.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ inputs.os }}-${{ steps.toolchain-install.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.lock') }}a

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,15 +4,18 @@ inputs:
   os:
     default: ubuntu-latest
   rusthash:
+    description: Unique hash from toolchain action
     required: true
 
-steps:
-  - uses: actions/cache@v3
-    with:
-      path: |
-        ~/.cargo/bin/
-        ~/.cargo/registry/index/
-        ~/.cargo/registry/cache/
-        ~/.cargo/git/db/
-        target/
-      key: ${{ inputs.os }}-${{ inputs.rusthash }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ inputs.os }}-${{ inputs.rusthash }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,10 +23,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
       - uses: ./.github/actions/setup
         with:
-          os: ${{ runner.os }}
+          os: ${{ matrix.os }}
           toolchain: ${{ matrix.rust }}
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: ['main']
   pull_request:
   schedule:
     - cron: "32 4 * * 5"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: ['main']
   pull_request:
   schedule:
     - cron: "32 4 * * 5"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
           toolchain: stable
           override: true
       - uses: ./.github/actions/setup
-        with:remove default
+        with:
           rusthash: ${{ steps.toolchain-install.outputs.rustc_hash }}
       - run: cargo test --package askama_actix --all-targets
       - run: cargo clippy --package askama_actix --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,8 +52,7 @@ jobs:
           toolchain: stable
           override: true
       - uses: ./.github/actions/setup
-        with:
-          os: ${{ runner.os }}
+        with:remove default
           rusthash: ${{ steps.toolchain-install.outputs.rustc_hash }}
       - run: cargo test --package askama_actix --all-targets
       - run: cargo clippy --package askama_actix --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,15 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        id: toolchain-install
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - uses: ./.github/actions/setup
+        with:
+          os: ${{ runner.os }}
+          rusthash: ${{ steps.toolchain-install.outputs.rustc_hash }}
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -41,10 +46,15 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        id: toolchain-install
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: ./.github/actions/setup
+        with:
+          os: ${{ runner.os }}
+          rusthash: ${{ steps.toolchain-install.outputs.rustc_hash }}
       - run: cargo test --package askama_actix --all-targets
       - run: cargo clippy --package askama_actix --all-targets -- -D warnings
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        id: toolchain-install
         with:
           profile: minimal
           toolchain: stable
@@ -75,6 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        id: toolchain-install      
         with:
           profile: minimal
           toolchain: stable
@@ -88,6 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        id: toolchain-install
         with:
           profile: minimal
           toolchain: stable
@@ -101,6 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        id: toolchain-install      
         with:
           profile: minimal
           toolchain: stable
@@ -114,6 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        id: toolchain-install      
         with:
           profile: minimal
           toolchain: stable
@@ -127,6 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        id: toolchain-install
         with:
           profile: minimal
           toolchain: stable
@@ -140,6 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
+        id: toolchain-install
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,15 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
-        id: toolchain-install
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
       - uses: ./.github/actions/setup
         with:
           os: ${{ runner.os }}
-          rusthash: ${{ steps.toolchain-install.outputs.rustc_hash }}
+          toolchain: ${{ matrix.rust }}
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -45,15 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        id: toolchain-install
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - uses: ./.github/actions/setup
-        with:
-          rusthash: ${{ steps.toolchain-install.outputs.rustc_hash }}
       - run: cargo test --package askama_actix --all-targets
       - run: cargo clippy --package askama_actix --all-targets -- -D warnings
 
@@ -61,12 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        id: toolchain-install
+      - uses: ./.github/actions/setup
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - run: cargo test --package askama_axum --all-targets
       - run: cargo clippy --package askama_axum --all-targets -- -D warnings
@@ -75,12 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        id: toolchain-install      
+      - uses: ./.github/actions/setup
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - run: cargo test --package askama_gotham --all-targets
       - run: cargo clippy --package askama_gotham --all-targets -- -D warnings
@@ -89,12 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        id: toolchain-install
+      - uses: ./.github/actions/setup
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - run: cargo test --package askama_rocket --all-targets
       - run: cargo clippy --package askama_rocket --all-targets -- -D warnings
@@ -103,12 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        id: toolchain-install      
+      - uses: ./.github/actions/setup
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - run: cargo test --package askama_warp --all-targets
       - run: cargo clippy --package askama_warp --all-targets -- -D warnings
@@ -117,12 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        id: toolchain-install      
+      - uses: ./.github/actions/setup
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - run: cargo test --package askama_tide --all-targets
       - run: cargo clippy --package askama_tide --all-targets -- -D warnings
@@ -131,12 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        id: toolchain-install
+      - uses: ./.github/actions/setup
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - run: cargo test --package askama_mendes --all-targets
       - run: cargo clippy --package askama_mendes --all-targets -- -D warnings
@@ -145,12 +108,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        id: toolchain-install
+      - uses: ./.github/actions/setup
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
- Adds GitHub caching step to shorten installation and build times.
- Extracts toolchain step into `setup` action to absorb commonalities

The cached folders are the suggested ones from the github's official [caching action](https://github.com/actions/cache/blob/main/examples.md#rust---cargo).